### PR TITLE
PHPDoc Updates

### DIFF
--- a/manuscript/converted/chapter15.txt
+++ b/manuscript/converted/chapter15.txt
@@ -17,15 +17,15 @@ Below is an example of how you might document a class with a few methods;
 /**
  * @author A Name <a.name@example.com>
  * @link http://www.phpdoc.org/docs/latest/index.html
- * @package helper
  */
 class DateTimeHelper
 {
     /**
      * @param mixed $anything Anything that we can convert to a \DateTime object
      *
-     * @return \DateTime
      * @throws \InvalidArgumentException
+     *
+     * @return \DateTime
      */
     public function dateTimeFromAnything($anything)
     {


### PR DESCRIPTION
I've updated the throws/returns order and separation to match the style inferred by the examples in the proposed psr docblock standard.

I've also removed the package annotation because I don't consider it meaningful and thus shouldn't be recommended in my opinion. Namespaces describe the package something belongs to well enough. :)
